### PR TITLE
fix: push constants

### DIFF
--- a/rostsd_gen/index.js
+++ b/rostsd_gen/index.js
@@ -303,11 +303,21 @@ function saveMsgConstructorAsTSD(rosMsgInterface, fd) {
   const type = rosMsgInterface.type();
   const msgName = type.interfaceName;
 
+  fs.writeSync(fd, `      export interface ${msgName}Constants {\n`);
+  for (const constant of rosMsgInterface.ROSMessageDef.constants) {
+    if(primitiveType2JSName(constant.type) === "string"){
+      fs.writeSync(fd, `        ${constant.name} = "${constant.value}";\n`);
+    } else {
+      fs.writeSync(fd, `        ${constant.name} = ${constant.value};\n`);
+    }
+  }
+  fs.writeSync(fd, '      }\n');
+
+
   fs.writeSync(fd, `      export interface ${msgName}Constructor {\n`);
 
   for (const constant of rosMsgInterface.ROSMessageDef.constants) {
-    const constantType = primitiveType2JSName(constant.type);
-    fs.writeSync(fd, `        readonly ${constant.name}: ${constantType};\n`);
+    s.writeSync(fd, `        readonly ${constant.name}: ${msgName}Constants.${constant.name};\n`);
   }
 
   fs.writeSync(fd, `        new(other?: ${msgName}): ${msgName};\n`);

--- a/rostsd_gen/index.js
+++ b/rostsd_gen/index.js
@@ -306,9 +306,9 @@ function saveMsgConstructorAsTSD(rosMsgInterface, fd) {
   fs.writeSync(fd, `      export interface ${msgName}Constants {\n`);
   for (const constant of rosMsgInterface.ROSMessageDef.constants) {
     if(primitiveType2JSName(constant.type) === "string"){
-      fs.writeSync(fd, `        ${constant.name} = "${constant.value}";\n`);
+      fs.writeSync(fd, `        ${constant.name} = "${constant.value}",\n`);
     } else {
-      fs.writeSync(fd, `        ${constant.name} = ${constant.value};\n`);
+      fs.writeSync(fd, `        ${constant.name} = ${constant.value},\n`);
     }
   }
   fs.writeSync(fd, '      }\n');


### PR DESCRIPTION
Changes 
```
      export interface MsgFwForkData {
        timestamp: builtin_interfaces.msg.Time;
        timestamp_us: number;
        position: number;
        status: number;
      }
      export interface MsgFwForkDataConstructor {
        readonly STATUS_NONE: number;
        readonly STATUS_STOPPED: number;
        new(other?: MsgFwForkData): MsgFwForkData;
      }
```

to 

```
      export interface MsgFwForkData {
        timestamp: builtin_interfaces.msg.Time;
        timestamp_us: number;
        position: number;
        status: number;
      }
       export enum MsgFwForkDataConstants{
        STATUS_NONE = 1,
        STATUS_STOPPED = 2,
      }
      export interface MsgFwForkDataConstructor {
        readonly STATUS_NONE: MsgFwForkDataConstants.STATUS_NONE;
        readonly STATUS_STOPPED: MsgFwForkDataConstants.STATUS_STOPPED;
        new(other?: MsgFwForkData): MsgFwForkData;
      }
```